### PR TITLE
Fix invalid range unit override

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The middleware can be configured with the following parameters:
 
 - `allowAll`: Whether to accept `*` as range-specifier.
 - `maximum`: Maximum number of items allowed per page (`50` by default).
-- `unit`: Range unit to be used when no `Range` header is provided (`items` by default).
+- `unit`: Accepted range unit (`items` by default).
 
 You can change the defaults by doing:
 

--- a/src/index.js
+++ b/src/index.js
@@ -42,10 +42,13 @@ function middleware({ allowAll = true, maximum = 50, unit = 'items' } = {}) {
         throw new MalformedRangeError();
       }
 
-      // Update `limit`, `offset` and `unit` values.
+      if (range.unit !== unit) {
+        throw new MalformedRangeError();
+      }
+
+      // Update `limit`, `offset` values.
       first = range.first;
       last = range.last;
-      unit = range.unit;
 
       if (!allowAll && last === '*') {
         throw new RangeNotSatisfiableError();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -116,6 +116,15 @@ describe('middleware', () => {
       .expect(412, 'Precondition Failed');
   });
 
+  it('should return 412 if the `Range` unit is not supported', () => {
+    app.use(middleware({ unit: 'bytes' }));
+
+    return request(server)
+      .get('/')
+      .set('Range', 'items=0-*')
+      .expect(412);
+  });
+
   it('should return 416 if the `Range` is invalid', () => {
     app.use(middleware());
 
@@ -277,19 +286,6 @@ describe('middleware', () => {
     return request(server)
       .get('/')
       .set('Range', `items=${firstPosition}-5`);
-  });
-
-  it('should expose the given `range-unit`', () => {
-    app.use(middleware({ unit: 'bytes' }));
-
-    app.use(ctx => {
-      expect(ctx.pagination.unit).toEqual('foobar');
-    });
-
-    return request(server)
-      .get('/')
-      .set('Range', 'foobar=0-5')
-      .expect('Content-Range', 'foobar 0-5/*');
   });
 
   it('should set the `byte-range-spec` to `*` if length is 0', () => {


### PR DESCRIPTION
Fixes a bug where the accepted range unit was not being respected.

Note that this is a BC on the current behavior.