### PR TITLE
Remove is-safe-integer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "debug": "^2.6.3",
     "http-content-range-format": "^1.0.0",
-    "is-safe-integer": "^1.0.2",
     "range-specifier-parser": "^1.0.2",
     "standard-http-error": "^2.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@
 
 const contentRangeFormat = require('http-content-range-format');
 const errors = require('./errors');
-const isSafeInteger = require('is-safe-integer');
 const rangeSpecifierParser = require('range-specifier-parser').default;
 
 /**
@@ -26,7 +25,7 @@ function middleware({ allowAll = true, maximum = 50, unit = 'items' } = {}) {
     let limit = '*';
 
     // Prevent invalid `maximum` value configuration.
-    if (!isFinite(maximum) || !isSafeInteger(maximum) || maximum <= 0) {
+    if (!isFinite(maximum) || !Number.isSafeInteger(maximum) || maximum <= 0) {
       throw new InvalidConfigurationError();
     }
 
@@ -54,12 +53,12 @@ function middleware({ allowAll = true, maximum = 50, unit = 'items' } = {}) {
         throw new RangeNotSatisfiableError();
       }
 
-      if (!isSafeInteger(first) || last !== '*' && !isSafeInteger(last)) {
+      if (!Number.isSafeInteger(first) || last !== '*' && !Number.isSafeInteger(last)) {
         throw new RangeNotSatisfiableError();
       }
     }
 
-    if (isSafeInteger(last)) {
+    if (Number.isSafeInteger(last)) {
       // Prevent pages to be longer than allowed.
       if (last - first + 1 > maximum) {
         last = first + maximum - 1;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1407,12 +1407,6 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
-is-safe-integer@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-safe-integer/-/is-safe-integer-1.0.2.tgz#ca2de0251f564408f9d7630c28e2e02ce18ea0aa"
-  dependencies:
-    max-safe-integer "^1.0.0"
-
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
@@ -1982,10 +1976,6 @@ makeerror@1.0.x:
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
   dependencies:
     tmpl "1.0.x"
-
-max-safe-integer@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/max-safe-integer/-/max-safe-integer-1.0.1.tgz#f38060be2c563d8c02e6d48af39122fd83b6f410"
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
No longer needed since ES2015 (Node 4+). In fact, [is-safe-integer](https://github.com/sindresorhus/is-safe-integer) is deprecated.